### PR TITLE
Fix typos on the Homepage and Projects page

### DIFF
--- a/components/FeaturedProjects.vue
+++ b/components/FeaturedProjects.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="space-y-6 relative">
     <h2 class="uppercase text-sm font-semibold text-gray-400">
-      FEATURED PROEJCTS
+      FEATURED PROJECTS
     </h2>
     <div class="flex flex-row flex-wrap justify-between">
       <card-featured-project

--- a/pages/projects.vue
+++ b/pages/projects.vue
@@ -9,7 +9,7 @@
     <featured-projects class="mb-16" />
 
     <h2 class="uppercase text-sm font-semibold text-gray-400 mb-6">
-      ALL PROEJCTS
+      ALL PROJECTS
     </h2>
     <div class="space-y-4">
       <card-project


### PR DESCRIPTION
## Description

Hey 👋, just found your portfolio by walking randomly on the internet, it's really a clean site!

I found some typos so I decided to fix them. It didn't take much effort, but I hope it is helpful.

## Proof of work 📹

## Before

1. On the Homepage

![CleanShot 2024-07-08 at 17 28 37@2x](https://github.com/anhthang/blog/assets/27861064/6fdb046b-71cf-400a-9245-5aaddbda1d28)

2. On the Project page

![CleanShot 2024-07-08 at 17 32 44@2x](https://github.com/anhthang/blog/assets/27861064/1a30a8d3-6330-4fab-9198-f89201045be4)

## After

1. On the Homepage

![CleanShot 2024-07-08 at 17 32 24@2x](https://github.com/anhthang/blog/assets/27861064/cf0f1059-67c0-4b35-96ed-e167871e0a37)

2. On the Project page

![CleanShot 2024-07-08 at 17 32 57@2x](https://github.com/anhthang/blog/assets/27861064/5bc4a0c3-d482-4c7b-8054-7542887cb8da)
